### PR TITLE
Include angular-material-sidemenu.css

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,10 @@
     "Navigation",
     "Sidemenu"
   ],
-  "main": "dest/angular-material-sidemenu.js",
+  "main": [
+    "dest/angular-material-sidemenu.js",
+    "dest/angular-material-sidemenu.css"
+  ],
   "license": "MIT",
   "ignore": [
     "node_modules",


### PR DESCRIPTION
Include angular-material-sidemenu.css. With this change wiredep/grunt-wiredep will automaticaly include the style sheet.