### PR TITLE
Define license as MIT

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2015 Kyle E. Mitchell and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,8 @@
   "projectName": "Angular Material Sidemenu",
   "name": "angular-material-sidemenu",
   "description": "A simple sidemenu for Angular Material",
-  "version": "1.0.2",
+  "version": "1.0.3",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/marcosmoura/angular-material-sidemenu.git"
@@ -21,7 +22,6 @@
     "dest/angular-material-sidemenu.js",
     "dest/angular-material-sidemenu.css"
   ],
-  "license": "MIT",
   "ignore": [
     "node_modules",
     "bower_components"

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "projectName": "Angular Material Sidemenu",
   "name": "angular-material-sidemenu",
   "description": "A simple sidemenu for Angular Material",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "projectName": "Angular Material Sidemenu",
   "name": "angular-material-sidemenu",
   "description": "A simple sidemenu for Angular Material",
-  "version": "1.0.2",
+  "version": "1.0.3",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/marcosmoura/angular-material-sidemenu.git"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "projectName": "Angular Material Sidemenu",
   "name": "angular-material-sidemenu",
   "description": "A simple sidemenu for Angular Material",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The [license-checker](https://github.com/davglass/license-checker) list the license of this project as UNKNOWN.

Please define a file named [LICENSE.txt or LICENSE.md](https://help.github.com/articles/open-source-licensing/#where-does-the-license-live-on-my-repository) and set it on package.json.